### PR TITLE
Add similarity search demo with simple chatbot

### DIFF
--- a/mcp-spring-boot-mongo-rag/README.md
+++ b/mcp-spring-boot-mongo-rag/README.md
@@ -49,4 +49,16 @@ mcp-spring-boot-mongo-rag
    mvn spring-boot:run
    ```
 
+## New Features
+
+The project now includes a very simple similarity search and chatbot endpoint, along with a demo of `$graphLookup`.
+
+- `POST /rag` &ndash; add a document. Each document stores a basic embedding.
+- `GET /rag/search?q=text` &ndash; fetch the document and its linked neighbors using `$graphLookup`.
+- `GET /rag/similarity?q=your+query` &ndash; returns the top matching documents using cosine similarity.
+- `GET /rag/chat?q=your+question` &ndash; a toy chat endpoint that replies with the text of the most similar document.
+- `GET /rag/chat-graph?q=your+question` &ndash; uses a graph lookup to traverse linked docs for a basic conversation.
+
+Embeddings are generated using a trivial length/character average approach in `EmbeddingUtil` to keep the example self-contained.
+
 This example gives you a starting point to explore MongoDB Graph RAG in a Spring Boot application.

--- a/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/controller/RagController.java
+++ b/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/controller/RagController.java
@@ -24,4 +24,23 @@ public class RagController {
     public List<Document> search(@RequestParam String q) {
         return ragService.graphSearch(q);
     }
+
+    @GetMapping("/similarity")
+    public List<RagDocument> similarity(@RequestParam String q) {
+        return ragService.similaritySearch(q);
+    }
+
+    @GetMapping("/chat")
+    public String chat(@RequestParam String q) {
+        List<RagDocument> docs = ragService.similaritySearch(q);
+        if (docs.isEmpty()) {
+            return "I couldn't find an answer.";
+        }
+        return docs.get(0).getText();
+    }
+
+    @GetMapping("/chat-graph")
+    public String chatGraph(@RequestParam String q) {
+        return ragService.graphChat(q);
+    }
 }

--- a/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/model/RagDocument.java
+++ b/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/model/RagDocument.java
@@ -8,6 +8,8 @@ public class RagDocument {
     @Id
     private String id;
     private String text;
+    private double[] embedding;
+    private java.util.List<String> relatedIds;
 
     public RagDocument() {
     }
@@ -30,5 +32,21 @@ public class RagDocument {
 
     public void setText(String text) {
         this.text = text;
+    }
+
+    public double[] getEmbedding() {
+        return embedding;
+    }
+
+    public void setEmbedding(double[] embedding) {
+        this.embedding = embedding;
+    }
+
+    public java.util.List<String> getRelatedIds() {
+        return relatedIds;
+    }
+
+    public void setRelatedIds(java.util.List<String> relatedIds) {
+        this.relatedIds = relatedIds;
     }
 }

--- a/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/service/RagService.java
+++ b/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/service/RagService.java
@@ -1,6 +1,7 @@
 package com.example.rag.service;
 
 import com.example.rag.model.RagDocument;
+import com.example.rag.util.EmbeddingUtil;
 import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -15,14 +16,55 @@ public class RagService {
     private MongoTemplate mongoTemplate;
 
     public List<Document> graphSearch(String query) {
-        // This is a placeholder for a $graphLookup or $search operation
-        Document stage = new Document("$match", new Document("text", query));
+        Document match = new Document("$match", new Document("text", query));
+        Document lookup = new Document("$graphLookup",
+                new Document("from", "docs")
+                        .append("startWith", "$relatedIds")
+                        .append("connectFromField", "relatedIds")
+                        .append("connectToField", "_id")
+                        .append("as", "neighbors")
+                        .append("maxDepth", 2));
         return mongoTemplate.getCollection("docs")
-                .aggregate(List.of(stage))
+                .aggregate(List.of(match, lookup))
                 .into(new java.util.ArrayList<>());
     }
 
+    public String graphChat(String query) {
+        List<Document> result = graphSearch(query);
+        if (result.isEmpty()) {
+            return "I couldn't find an answer.";
+        }
+        Document doc = result.get(0);
+        String answer = doc.getString("text");
+        @SuppressWarnings("unchecked")
+        List<Document> neighbors = (List<Document>) doc.get("neighbors");
+        if (neighbors != null && !neighbors.isEmpty()) {
+            String next = neighbors.get(0).getString("text");
+            if (next != null) {
+                answer += " " + next;
+            }
+        }
+        return answer;
+    }
+
+    public List<RagDocument> similaritySearch(String query) {
+        double[] qVec = EmbeddingUtil.embed(query);
+        List<RagDocument> all = mongoTemplate.findAll(RagDocument.class);
+        return all.stream()
+                .sorted((a, b) -> {
+                    double simA = EmbeddingUtil.cosineSimilarity(qVec, a.getEmbedding());
+                    double simB = EmbeddingUtil.cosineSimilarity(qVec, b.getEmbedding());
+                    return Double.compare(simB, simA);
+                })
+                .limit(5)
+                .toList();
+    }
+
     public RagDocument save(RagDocument doc) {
+        doc.setEmbedding(EmbeddingUtil.embed(doc.getText()));
+        if (doc.getRelatedIds() == null) {
+            doc.setRelatedIds(java.util.Collections.emptyList());
+        }
         return mongoTemplate.save(doc);
     }
 }

--- a/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/util/EmbeddingUtil.java
+++ b/mcp-spring-boot-mongo-rag/src/main/java/com/example/rag/util/EmbeddingUtil.java
@@ -1,0 +1,31 @@
+package com.example.rag.util;
+
+public class EmbeddingUtil {
+    public static double[] embed(String text) {
+        // simple embedding based on length and average character code
+        if (text == null || text.isEmpty()) {
+            return new double[]{0.0, 0.0};
+        }
+        double length = text.length();
+        double avg = text.chars().average().orElse(0.0);
+        return new double[]{length, avg};
+    }
+
+    public static double cosineSimilarity(double[] v1, double[] v2) {
+        if (v1.length != v2.length) {
+            throw new IllegalArgumentException("Vectors must be the same length");
+        }
+        double dot = 0.0;
+        double mag1 = 0.0;
+        double mag2 = 0.0;
+        for (int i = 0; i < v1.length; i++) {
+            dot += v1[i] * v2[i];
+            mag1 += v1[i] * v1[i];
+            mag2 += v2[i] * v2[i];
+        }
+        if (mag1 == 0 || mag2 == 0) {
+            return 0.0;
+        }
+        return dot / (Math.sqrt(mag1) * Math.sqrt(mag2));
+    }
+}


### PR DESCRIPTION
## Summary
- add `EmbeddingUtil` with trivial embedding and cosine similarity
- store embeddings and doc links in `RagDocument`
- implement `$graphLookup` search and conversation in `RagService`
- expose new `/chat-graph` endpoint
- document all endpoints in the README

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f464bf7c83219b1785eb66046d2b